### PR TITLE
Revert "Return 0 decimals"

### DIFF
--- a/contracts/ERC20Wrapper.sol
+++ b/contracts/ERC20Wrapper.sol
@@ -35,8 +35,14 @@ abstract contract ERC20Wrapper is ERC20 {
     /**
      * @dev See {ERC20-decimals}.
      */
-    function decimals() public view virtual override returns (uint8) { 
-        return 0;
+    function decimals() public view virtual override returns (uint8) {
+        try IERC20Metadata(address(underlying)).decimals() returns (
+            uint8 value
+        ) {
+            return value;
+        } catch {
+            return super.decimals();
+        }
     }
 
     /**


### PR DESCRIPTION
Reverts w3hc/gcfa#36 because it doesn't manage at all the decimals of the € token wrapped.